### PR TITLE
Bump ntfy server version (1.25.2 => 1.26.0)

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   ntfy:
     container_name: ci_ntfy
-    image: binwiederhier/ntfy:v1.25.2
+    image: binwiederhier/ntfy:v1.26.0
     command: serve
     volumes:
      - './ntfy-server.yml:/etc/ntfy/server.yml'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 PHP library for sending messages using a [ntfy](https://github.com/binwiederhier/ntfy) server.
 
-Supports ntfy server version 1.25.2.
+Supports ntfy server version 1.26.0.
 
 ## Install
 


### PR DESCRIPTION
https://github.com/binwiederhier/ntfy/releases/tag/v1.26.0