### PR TITLE
[Message] Add icon support

### DIFF
--- a/docs/classes/message.md
+++ b/docs/classes/message.md
@@ -93,6 +93,12 @@ Set email address for sending a email notification
 email(string $email): void
 ```
 
+Set URL for message notification icon
+
+```PHP
+icon(string $url): void
+```
+
 Set a file attachment using a URL
 
 ```PHP

--- a/src/Message.php
+++ b/src/Message.php
@@ -76,6 +76,9 @@ class Message
 	/** @var string $email Email address for e-mail notifications */
 	private string $email = '';
 
+	/** @var string $icon URL of the message notification icon */
+	private string $icon = '';
+
 	/** @var string $attachFilename Name of file attachment */
 	private string $attachFilename = '';
 
@@ -201,6 +204,18 @@ class Message
 	public function email(string $email): void
 	{
 		$this->email = $email;
+	}
+
+	/**
+	 * Set URL for message notification icon
+	 *
+	 * @param string $url icon URL
+	 *
+	 * @see https://ntfy.sh/docs/publish/#icons
+	 */
+	public function icon(string $url): void
+	{
+		$this->icon = $url;
 	}
 
 	/**

--- a/src/Message.php
+++ b/src/Message.php
@@ -343,6 +343,10 @@ class Message
 			$data['email'] = $this->email;
 		}
 
+		if ($this->icon !== '') {
+			$data['icon'] = $this->icon;
+		}
+
 		if ($this->cache === false) {
 			$data['cache'] = 'no';
 		}

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -18,7 +18,7 @@ class MessageTest extends TestCase
 	private array $tags = ['hello', 'world'];
 
 	/** @var string $priority Message icon */
-	private string $icon = 'https://ntfy.sh/static/img/ntfy.png'; 
+	private string $icon = 'https://ntfy.sh/static/img/ntfy.png';
 
 	/** @var string $attachmentUrl File attachment URL */
 	private string $attachmentUrl = 'https://example.com/index.html';

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -17,6 +17,9 @@ class MessageTest extends TestCase
 	/** @var array<int, string> $tags Message tags */
 	private array $tags = ['hello', 'world'];
 
+	/** @var string $priority Message icon */
+	private string $icon = 'https://ntfy.sh/static/img/ntfy.png'; 
+
 	/** @var string $attachmentUrl File attachment URL */
 	private string $attachmentUrl = 'https://example.com/index.html';
 
@@ -50,6 +53,7 @@ class MessageTest extends TestCase
 		$message->title($this->title);
 		$message->body($this->body);
 		$message->tags($this->tags);
+		$message->icon($this->icon);
 		$message->priority($this->priority);
 		$message->action($action);
 		$message->attachURL(
@@ -63,6 +67,7 @@ class MessageTest extends TestCase
 		$this->assertObjectHasAttribute('topic', $details);
 		$this->assertObjectHasAttribute('title', $details);
 		$this->assertObjectHasAttribute('message', $details);
+		$this->assertObjectHasAttribute('icon', $details);
 		$this->assertObjectHasAttribute('priority', $details);
 		$this->assertObjectHasAttribute('actions', $details);
 
@@ -70,6 +75,7 @@ class MessageTest extends TestCase
 		$this->assertEquals($this->title, $details->title);
 		$this->assertEquals($this->body, $details->message);
 		$this->assertEquals($this->tags, $details->tags);
+		$this->assertEquals($this->icon, $details->icon);
 		$this->assertEquals($this->priority, $details->priority);
 
 		$this->assertCount(1, $details->actions);


### PR DESCRIPTION
Adds notification icon support to Message class. I somehow missed this new feature when reviewing the [v1.28.0](https://github.com/binwiederhier/ntfy/releases/tag/v1.28.0) release notes.

Todo:

- [x] Add to message test. 