### PR TITLE
devcontainer: Remove extension recca0120.vscode-phpunit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,7 @@
             "extensions": [
                 "EditorConfig.EditorConfig",
                 "streetsidesoftware.code-spell-checker",
-                "bmewburn.vscode-intelephense-client",
-                "recca0120.vscode-phpunit"
+                "bmewburn.vscode-intelephense-client"
             ]
         }
     },


### PR DESCRIPTION
Removes VS Code extension `recca0120.vscode-phpunit` from devcontainer.