### PR TITLE
Bump mccutchen/go-httpbin from 2.9.2 to 2.10.0

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   httpbin:
     container_name: ci_httpbin
-    image: mccutchen/go-httpbin:v2.9.2
+    image: mccutchen/go-httpbin:v2.10.0
     command: ["go-httpbin", "-port", "80"]
     ports:
       - "127.0.0.1:8081:80"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   httpbin:
     container_name: httpbin
-    image: mccutchen/go-httpbin:v2.9.2
+    image: mccutchen/go-httpbin:v2.10.0
     command: ["go-httpbin", "-port", "80"]
     ports:
       - "127.0.0.1:8081:80"


### PR DESCRIPTION
https://github.com/mccutchen/go-httpbin/releases/tag/v2.10.0