### PR TITLE
Fixes deprecation notice in Guzzle class function `getConfig`

### DIFF
--- a/src/Guzzle.php
+++ b/src/Guzzle.php
@@ -128,7 +128,7 @@ class Guzzle
     *  @param ?HandlerStack $handlerStack Guzzle handler stack
      * @return array<string, mixed> Returns client config array
      */
-    private function getConfig(string $uri, ?AbstractAuth $auth, ?HandlerStack $handlerStack): array
+    private function getConfig(string $uri, ?AbstractAuth $auth, ?HandlerStack $handlerStack = null): array
     {
         $config = [
             'base_uri' => $uri,


### PR DESCRIPTION
 Fixes deprecation notice in Guzzle class function `getConfig` when running on php 8.3

> Deprecated: Optional parameter $auth declared before required parameter $handlerStack is implicitly treated as a required parameter in verifiedjoseph/ntfy-php-library/src/Guzzle.php on line 131